### PR TITLE
Bugfix UCP Loadout

### DIFF
--- a/factions/UsUCP.hpp
+++ b/factions/UsUCP.hpp
@@ -21,7 +21,7 @@
 #endif
 
 class USUCP: USOCP {
-    class AllUnits {
+    class AllUnits: AllUnits {
         uniform = "rhs_uniform_cu_ucp";
         vest = "rhsusf_iotv_ocp_Rifleman";
         backpack = "";


### PR DESCRIPTION
UCP Loadout was not properly inherited from OCP AllUnits class. Included AllUnits class from OCP and loadout now seems to be properly applied across the board.